### PR TITLE
pass along sd_journal_wait() return value.

### DIFF
--- a/lib/systemd/journal.rb
+++ b/lib/systemd/journal.rb
@@ -176,9 +176,13 @@ module Systemd
     #   j = Systemd::Journal.new
     #   j.seek(:tail)
     #   j.wait(3 * 1_000_000)
+    # @return [Symbol] :nop if the wait time was reached (no events occured).
+    # @return [Symbol] :append if new entries were appened to the journal.
+    # @return [Symbol] :invalidate if journal files were added/removed/rotated.
     def wait(timeout_usec = -1)
       rc = Native::sd_journal_wait(@ptr, timeout_usec)
-      raise JournalError.new(rc) if rc < 0
+      raise JournalError.new(rc) if rc.is_a?(Fixnum) && rc < 0
+      rc
     end
 
     # Add a filter to journal, such that only entries where the given filter

--- a/lib/systemd/journal/native.rb
+++ b/lib/systemd/journal/native.rb
@@ -28,7 +28,12 @@ module Systemd
       attach_function :sd_journal_enumerate_data, [:pointer, :pointer, :pointer], :int
 
       # event notification
-      attach_function :sd_journal_wait, [:pointer, :uint64], :int
+      enum :wake_reason, [
+        :nop,
+        :append,
+        :invalidate
+      ]
+      attach_function :sd_journal_wait, [:pointer, :uint64], :wake_reason
 
       # filtering
       attach_function :sd_journal_add_match,       [:pointer, :string, :size_t], :int


### PR DESCRIPTION
Translate the return value from `sd_journal_wait()` to a symbol if it's not an error, and return it from `Journal#wait`.
