### PR TITLE
Fix memory leak in `Journal#cursor`.

### DIFF
--- a/lib/systemd/journal.rb
+++ b/lib/systemd/journal.rb
@@ -406,7 +406,7 @@ module Systemd
         raise JournalError.new(rc)
       end
 
-      out_ptr.read_pointer.read_string
+      read_and_free_outstr(out_ptr.read_pointer)
     end
 
     # Check if the read position is currently at the entry represented by the
@@ -426,6 +426,15 @@ module Systemd
 
     def self.finalize(ptr)
       proc{ Native::sd_journal_close(ptr) unless ptr.nil? }
+    end
+
+    # some sd_journal_* functions return strings that we're expected to free
+    # ourselves.  This function copies the string from a char* to a ruby string,
+    # frees the char*, and returns the ruby string.
+    def read_and_free_outstr(ptr)
+      str = ptr.read_string
+      LibC.free(ptr)
+      str
     end
 
   end

--- a/lib/systemd/journal/native.rb
+++ b/lib/systemd/journal/native.rb
@@ -62,4 +62,13 @@ module Systemd
     end
 
   end unless $NO_FFI_SPEC
+
+  module LibC
+    require 'ffi'
+    extend FFI::Library
+    ffi_lib FFI::Library::LIBC
+
+    attach_function :free, [:pointer], :void
+  end
+
 end

--- a/spec/systemd/journal_spec.rb
+++ b/spec/systemd/journal_spec.rb
@@ -429,8 +429,14 @@ describe Systemd::Journal do
   describe '#cursor' do
     it 'returns the current cursor' do
       j = Systemd::Journal.new
+
       Systemd::Journal::Native.should_receive(:sd_journal_get_cursor) do |ptr, out_ptr|
-        out_ptr.write_pointer(FFI::MemoryPointer.from_string("5678"))
+        # this memory will be manually freed. not setting autorelease to false
+        # would cause a double free.
+        str = FFI::MemoryPointer.from_string("5678")
+        str.autorelease = false
+
+        out_ptr.write_pointer(str)
         0
       end
       j.cursor.should eq("5678")


### PR DESCRIPTION
`sd_journal_get_cursor` expects the caller to free the allocated string.  Previously we were not doing this.
