### PR TITLE
Remove sd_journal_open_container as it's not in systemd 208 and isn't used

### DIFF
--- a/lib/systemd/journal/native.rb
+++ b/lib/systemd/journal/native.rb
@@ -17,7 +17,6 @@ module Systemd
       attach_function :sd_journal_close,          [:pointer], :void
 
       attach_function :sd_journal_open_files,     [:pointer, :pointer, :int], :int
-      attach_function :sd_journal_open_container, [:pointer, :string, :int], :int
 
       # navigation
       attach_function :sd_journal_next,          [:pointer], :int


### PR DESCRIPTION
Hi there,

The function sd_journal_open_container isn't available in systemd 208, it was added in 209:

http://cgit.freedesktop.org/systemd/systemd/commit/?id=b6741478e7661c7e580e5dcfd6a6fccd1899c1d0&utm_source=anzwix

I'm not sure why it's available in Arch, but in Fedora 20 it's still missing. Perhaps it has been backported there? Since this function isn't actually used by this gem, we should be able to just drop it for now.
