### PR TITLE
Add syntax highlighting to readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,29 @@ Ruby bindings for reading from the systemd journal.
 
 Add this line to your application's Gemfile:
 
-    gem 'systemd-journal', '~> 1.2.0'
+```ruby
+gem 'systemd-journal', '~> 1.2.0'
+```
 
 And then execute:
 
-    bundle install
+```sh
+bundle install
+```
 
 If you have trust issues, fear not:
 
-    wget https://github.com/ledbettj/systemd-journal/blob/master/certs/john@throttle.io.pem
-    gem cert --add john@throttle.io.pem
+```sh
+wget https://github.com/ledbettj/systemd-journal/blob/master/certs/john@throttle.io.pem
+gem cert --add john@throttle.io.pem
+```
 
 You can then verify the signature at install time with either `gem` or `bundler`:
 
-    gem install systemd-journal -P HighSecurity
-    bundle install --trust-policy HighSecurity
+```sh
+gem install systemd-journal -P HighSecurity
+bundle install --trust-policy HighSecurity
+```
 
 ## Dependencies
 
@@ -34,79 +42,93 @@ use the gem.  Currently we support systemd 208 or higher.
 
 ## Usage
 
-    require 'systemd/journal'
+```ruby
+require 'systemd/journal'
+```
 
 Print all messages as they occur:
 
-    j = Systemd::Journal.new
-    j.seek(:tail)
+```ruby
+j = Systemd::Journal.new
+j.seek(:tail)
 
-    # watch() does not return
-    j.watch do |entry|
-      puts entry.message
-    end
+# watch() does not return
+j.watch do |entry|
+  puts entry.message
+end
+```
 
 Filter events and iterate:
 
-    j = Systemd::Journal.new
+```ruby
+j = Systemd::Journal.new
 
-    # only display entries from SSHD with priority 6.
-    j.filter(priority: 6, _exe: '/usr/bin/sshd')
-    j.each do |entry|
-      puts entry.message
-    end
+# only display entries from SSHD with priority 6.
+j.filter(priority: 6, _exe: '/usr/bin/sshd')
+j.each do |entry|
+  puts entry.message
+end
+```
 
 Moving around the journal:
 
-    j = Systemd::Journal.new
+```ruby
+j = Systemd::Journal.new
 
-    j.seek(:head)   # move to the start of journal
-    j.move(10)      # move forward by 10 entries
-    c = j.cursor    # get a reference to this entry
-    j.move(-5)      # move back 5 entries
-    j.seek(c)       # move to the saved cursor
-    j.cursor?(c)    # verify that we're at the correct entry
-    j.seek(:tail)   # move to end of the journal
-    j.move_previous # move back
-    j.move_next     # move forward
+j.seek(:head)   # move to the start of journal
+j.move(10)      # move forward by 10 entries
+c = j.cursor    # get a reference to this entry
+j.move(-5)      # move back 5 entries
+j.seek(c)       # move to the saved cursor
+j.cursor?(c)    # verify that we're at the correct entry
+j.seek(:tail)   # move to end of the journal
+j.move_previous # move back
+j.move_next     # move forward
 
-    j.current_entry # get the entry we're currently positioned at
+j.current_entry # get the entry we're currently positioned at
 
-    # seek the entry that occured closest to this time
-    j.seek(Time.parse("2013-10-31T12:00:00+04:00:00"))
+# seek the entry that occured closest to this time
+j.seek(Time.parse('2013-10-31T12:00:00+04:00:00'))
+```
 
 Waiting for things to happen:
 
-    j = Systemd::Journal.new
-    j.seek(:tail)
-    # wait up to one second for something to happen
-    if j.wait(1_000_000)
-      puts 'something changed!'
-    # same as above, but can be interrupted with Control+C.
-    if j.wait(1_000_000, select: true)
-      puts 'something changed!'
+```ruby
+j = Systemd::Journal.new
+j.seek(:tail)
+# wait up to one second for something to happen
+if j.wait(1_000_000)
+  puts 'something changed!'
+# same as above, but can be interrupted with Control+C.
+if j.wait(1_000_000, select: true)
+  puts 'something changed!'
+```
 
 Accessing the catalog:
 
-    j = Systemd::Journal.new
-    j.move_next
-    j.move_next while !j.current_entry.catalog?
+```ruby
+j = Systemd::Journal.new
+j.move_next
+j.move_next while !j.current_entry.catalog?
 
-    puts j.current_entry.catalog
-    # or if you have a message id:
-    puts Systemd::Journal.catalog_for(j.current_entry.message_id)
+puts j.current_entry.catalog
+# or if you have a message id:
+puts Systemd::Journal.catalog_for(j.current_entry.message_id)
+```
 
 Writing to the journal:
 
-    # write a simple message
-    Systemd::Journal.print(Systemd::Journal::LOG_INFO, 'Something happened')
+```ruby
+# write a simple message
+Systemd::Journal.print(Systemd::Journal::LOG_INFO, 'Something happened')
 
-    # write custom fields
-    Systemd::Journal.message(
-      message: 'Something bad happened',
-      priority: Systemd::Journal::LOG_ERR,
-      my_custom_field: 'foo was nil!'
-    )
+# write custom fields
+Systemd::Journal.message(
+  message: 'Something bad happened',
+  priority: Systemd::Journal::LOG_ERR,
+  my_custom_field: 'foo was nil!'
+)
+```
 
 See the documentation for more examples.
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Accessing the catalog:
 ```ruby
 j = Systemd::Journal.new
 j.move_next
-j.move_next while !j.current_entry.catalog?
+j.move_next until j.current_entry.catalog?
 
 puts j.current_entry.catalog
 # or if you have a message id:


### PR DESCRIPTION
Also, a tweak to one of the examples, from:

```ruby
j.move_next while !j.current_entry.catalog?
```

To:

```ruby
j.move_next until j.current_entry.catalog?
```