### PR TITLE
Fix a bug where using LibC.free() can cause faults when using alternative malloc

### DIFF
--- a/lib/systemd/journal.rb
+++ b/lib/systemd/journal.rb
@@ -297,7 +297,7 @@ module Systemd
     # frees the char*, and returns the ruby string.
     def self.read_and_free_outstr(ptr)
       str = ptr.read_string
-      LibC.free(ptr)
+      ptr.free()
       str
     end
   end


### PR DESCRIPTION
While attempting to get the fluent-plugin-systemd to work with td-agent,
I was running into a problem where td-agent would suddenly die when
trying to access a cursor.

Upon further review, it was discovered that this did not happen if
LibC.free(ptr) was commented out in read_and_free_outstr(). Upon digging
into the issue deeper, it appears that td-agent is configured to use
jemalloc (via LD_PRELOAD). From what I can tell, LibC.free() attempts to
use the normal system malloc-based free instead of linking against the
jemalloc version. As a result, the attempt to free crashes the process.

I believe the best solution to the problem is to replace this call with
a call to ptr.free() which will allow FFI to handle this appropriately
and not crash the process.