### PR TITLE
try to be more explicit about seek(:tail) requiring move_previous.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Print all messages as they occur:
 ```ruby
 j = Systemd::Journal.new
 j.seek(:tail)
+j.move_previous
 
 # watch() does not return
 j.watch do |entry|
@@ -81,9 +82,9 @@ c = j.cursor    # get a reference to this entry
 j.move(-5)      # move back 5 entries
 j.seek(c)       # move to the saved cursor
 j.cursor?(c)    # verify that we're at the correct entry
-j.seek(:tail)   # move to end of the journal
-j.move_previous # move back
-j.move_next     # move forward
+j.seek(:tail)   # move past the end of the journal
+j.move_previous # move to last entry in journal
+j.move_next     # move forward (fails since we're at the end)
 
 j.current_entry # get the entry we're currently positioned at
 
@@ -96,6 +97,7 @@ Waiting for things to happen:
 ```ruby
 j = Systemd::Journal.new
 j.seek(:tail)
+j.move_previous
 # wait up to one second for something to happen
 if j.wait(1_000_000)
   puts 'something changed!'
@@ -145,7 +147,8 @@ a valid entry:
     Journal#seek(:tail)
 
 The solution is to always call one of `move`, `move_next`, `move_previous` and
-friends before reading after issuing one of the above calls.
+friends before reading after issuing one of the above calls.  For most functions,
+call `move_next`.  For `seek(:tail)`, call `move_previous`.
 
 ## Issues?
 

--- a/examples/ssh_watcher.rb
+++ b/examples/ssh_watcher.rb
@@ -10,6 +10,7 @@ class SSHWatcher
   def run
     @journal.filter(_exe: '/usr/bin/sshd')
     @journal.seek(:tail)
+    @journal.move_previous
     @journal.watch{ |entry| process_event(entry) }
   end
 

--- a/lib/systemd/journal/navigable.rb
+++ b/lib/systemd/journal/navigable.rb
@@ -78,6 +78,9 @@ module Systemd
       # Seek to a position in the journal.
       # Note: after seeking, you must call {#move_next} or {#move_previous}
       #   before you can call {#read_field} or {#current_entry}.
+      #   When calling `seek(:tail)` the read pointer is positioned _after_
+      #   the last entry in the journal -- thus you should use `move_previous`.
+      #   Otherwise, use `move_next`.
       #
       # @param [Symbol, Time] whence one of :head, :tail, or a Time instance.
       #   `:head` (or `:start`) will seek to the beginning of the journal.
@@ -86,6 +89,11 @@ module Systemd
       #   time. When a String is provided, assume it is a cursor from {#cursor}
       #   and seek to that entry.
       # @return [True]
+      # @example Read last journal entry
+      #   j = Systemd::Joural.new
+      #   j.seek(:tail)
+      #   j.move_previous
+      #   puts j.current_entry
       def seek(where)
         rc = case
              when [:head, :start].include?(where)


### PR DESCRIPTION
## Problem
Calling `move_next` after `seek(:tail)` results in the journal reading erroneous entries from random spots.
The right thing to do is to call `move_previous` immediately afterwards to position the read pointer at the last entry in the journal.  However several examples/code samples don't do this.

## Solution
Spell this out more clearly.