### PR TITLE
JRuby doesn't support 'read_uint64' method. Replace it with equivalent

### DIFF
--- a/lib/systemd/journal.rb
+++ b/lib/systemd/journal.rb
@@ -168,7 +168,7 @@ module Systemd
       rc = Native.sd_journal_get_usage(@ptr, size_ptr)
 
       raise JournalError, rc if rc < 0
-      size_ptr.read_uint64
+      size_ptr.read_ulong_long
     end
 
     # Get the maximum length of a data field that will be returned.
@@ -231,7 +231,7 @@ module Systemd
       rc = Native.sd_journal_get_realtime_usec(@ptr, out)
       raise JournalError, rc if rc < 0
 
-      out.read_uint64
+      out.read_ulong_long
     end
 
     def read_monotonic
@@ -241,7 +241,7 @@ module Systemd
       rc = Native.sd_journal_get_monotonic_usec(@ptr, out, boot)
       raise JournalError, rc if rc < 0
 
-      [out.read_uint64, Systemd::Id128::Native::Id128.new(boot).to_s]
+      [out.read_ulong_long, Systemd::Id128::Native::Id128.new(boot).to_s]
     end
 
     def array_to_ptrs(strings)


### PR DESCRIPTION
Here is an error in JRuby
```
NameError: undefined method 'read_uint64' for class 'FFI::MemoryPointer'
           alias_method at org/jruby/RubyModule.java:2671
  <class:MemoryPointer> at lib/systemd/ffi_size_t.rb:13
                  <top> at lib/systemd/ffi_size_t.rb:4
                require at org/jruby/RubyKernel.java:937
                 (root) at /nix/store/3rha5350dg0s5gsb1d7g2w80v3vy81gr-jruby-9.0.5.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
                  <top> at /nix/store/3rha5350dg0s5gsb1d7g2w80v3vy81gr-jruby-9.0.5.0/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:54
                require at org/jruby/RubyKernel.java:937
                 (root) at lib/systemd/journal.rb:13
                  <top> at test.rb:1
```

This may be as well a bug in JRuby. `read_ulong_long`, `get_uint64` and `get_ulong_long` have same  implementations:
https://github.com/jruby/jruby/blob/f7746d0be94f5d9f7cd27af610f1bc5dd2622794/core/src/main/java/org/jruby/ext/ffi/AbstractMemory.java#L777-L790

I may add a reproduce script, if you wish.