### PR TITLE
add ability to manually close the journal

### DIFF
--- a/lib/systemd/journal.rb
+++ b/lib/systemd/journal.rb
@@ -191,6 +191,22 @@ module Systemd
       end
     end
 
+    # Explicitly close the underlying Journal file.
+    # Once this is done, any operations on the instance will fail and raise an
+    # exception.
+    def close
+      return if @ptr.nil?
+
+      ObjectSpace.undefine_finalizer(self)
+      Native.sd_journal_close(@ptr)
+
+      @ptr = nil
+    end
+
+    def closed?
+      @ptr.nil?
+    end
+
     # @private
     def inspect
       format(

--- a/spec/systemd/journal_spec.rb
+++ b/spec/systemd/journal_spec.rb
@@ -25,6 +25,34 @@ RSpec.describe Systemd::Journal do
     end
   end
 
+  describe 'close' do
+    it 'closes the underlying file' do
+      expect(Systemd::Journal::Native).to receive(:sd_journal_close)
+        .and_call_original
+
+      j.close
+    end
+
+    it 'unregisters the finalizer' do
+      expect(ObjectSpace).to receive(:undefine_finalizer)
+        .with(j)
+        .and_call_original
+
+      j.close
+    end
+
+    it 'does not fail if called more than once' do
+      j.close
+      expect { j.close }.to_not raise_error
+    end
+
+    it 'marks the journal as closed' do
+      expect(j).to_not be_closed
+      j.close
+      expect(j).to be_closed
+    end
+  end
+
   describe 'query_unique' do
     it 'throws a JournalError on invalid return code' do
       expect(Systemd::Journal::Native).to receive(:sd_journal_enumerate_unique)


### PR DESCRIPTION
See #73 

In some instances it might be desirable to manually close the underlying journal file.  Turns out we can unregister the finalizer in this case and everything works great.