### PR TITLE
ensure percent signs are escaped in sd_journal_send

### DIFF
--- a/lib/systemd/journal/writable.rb
+++ b/lib/systemd/journal/writable.rb
@@ -74,7 +74,8 @@ module Systemd
         # @param [Hash] contents the set of key-value pairs defining the event.
         def message(contents)
           items = contents.flat_map do |k, v|
-            [:string, "#{k.to_s.upcase}=#{v}"]
+            value = v.to_s.gsub('%', '%%')
+            [:string, "#{k.to_s.upcase}=#{value}"]
           end
           # add a null pointer to terminate the varargs
           items += [:string, nil]

--- a/spec/systemd/journal_spec.rb
+++ b/spec/systemd/journal_spec.rb
@@ -410,4 +410,14 @@ RSpec.describe Systemd::Journal do
       expect([true, false]).to include(j.wait_select_reliable?)
     end
   end
+
+  describe 'message' do
+    it 'escapes percent signs in messages' do
+      expect(Systemd::Journal::Native).to receive(:sd_journal_send)
+        .with(:string, 'MESSAGE=hello %% world %%', :string, nil)
+        .and_return(0)
+
+      Systemd::Journal.message(message: 'hello % world %')
+    end
+  end
 end


### PR DESCRIPTION
See #76 

format specifiers need to be escaped before we pass down to the native library.