### PR TITLE
finalize needs to be removed from options and not flags

### DIFF
--- a/lib/systemd/journal.rb
+++ b/lib/systemd/journal.rb
@@ -48,7 +48,7 @@ module Systemd
       open_type, flags = validate_options!(opts)
       ptr = FFI::MemoryPointer.new(:pointer, 1)
 
-      @finalize = (flags.key?(:finalize) ? flags.delete(:finalize) : true)
+      @finalize = (opts.key?(:finalize) ? opts.delete(:finalize) : true)
       rc = open_journal(open_type, ptr, opts, flags)
       raise JournalError, rc if rc < 0
 


### PR DESCRIPTION
just ran into this error ... so seems to be missing tests :(

```
[01:27:14]   /app/vendor/bundle/ruby/2.5.0/gems/systemd-journal-1.4.0/lib/systemd/journal.rb:51:in `initialize': undefined method `key?' for 0:Integer (NoMethodError)
```

@ledbettj 