### PR TITLE
Escape % signs before passing to sd_journal_print

### DIFF
--- a/lib/systemd/journal/writable.rb
+++ b/lib/systemd/journal/writable.rb
@@ -66,7 +66,7 @@ module Systemd
         #   severity of the event.
         # @param [String] message the content of the message to write.
         def print(level, message)
-          rc = Native.sd_journal_print(level, message)
+          rc = Native.sd_journal_print(level, message.to_s.gsub('%', '%%'))
           raise JournalError, rc if rc < 0
         end
 

--- a/spec/systemd/journal_spec.rb
+++ b/spec/systemd/journal_spec.rb
@@ -438,4 +438,14 @@ RSpec.describe Systemd::Journal do
       Systemd::Journal.message(message: 'hello % world %')
     end
   end
+
+  describe 'print' do
+    it 'escapes percent signs' do
+      expect(Systemd::Journal::Native).to receive(:sd_journal_print)
+        .with(Systemd::Journal::LOG_DEBUG, 'hello %% world %%')
+        .and_return(0)
+
+      Systemd::Journal.print(Systemd::Journal::LOG_DEBUG, 'hello % world %')
+    end
+  end
 end


### PR DESCRIPTION
sd_journal_print is a variadic function that expects printf-like
formatters; passing unescaped % signs can trigger a segfault, for
example:  sd_journal_print("%s %s")

We already escape these % signs in sd_journal_send and we do not
accept format parameters in .print(), so there's no reason to allow
them to pass through unescaped.