### PR TITLE
Fix a crash bug when memory allocator implementation was changed

### DIFF
--- a/lib/systemd/journal.rb
+++ b/lib/systemd/journal.rb
@@ -322,7 +322,7 @@ module Systemd
     # frees the char*, and returns the ruby string.
     def self.read_and_free_outstr(ptr)
       str = ptr.read_string
-      LibC.free(ptr)
+      ptr.free
       str
     end
   end


### PR DESCRIPTION
Follow up #62.

When systemd-journal was used from fluent-plugin-systemd, there is a case that it causes a SEGV.

```
  free(): invalid pointer
```

In the previous versions, systemd-journal gem calls libc's free() explicitly for FFI::Pointer.

It is okay if you use default memory allocator, but if you use alternative implementation such as jemalloc (via LD_PRELOAD), it causes a disaster to happen (SEGV) with inconsistent call.

It seems that it is appropriate calling ptr.free here instead of LibC.free which will allow FFI to handle this case and not let crash the process.