### PR TITLE
Add a native extension shim for calling free()

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: [3.0, 3.1, 3.2, 3.3, jruby]
+        ruby: [3.0, 3.1, 3.2, 3.3]
     runs-on: ${{ matrix.os }}-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,13 +6,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: [2.5, 2.6, 2.7, 3.0, jruby]
+        ruby: [3.0, 3.1, 3.2, 3.3, jruby]
     runs-on: ${{ matrix.os }}-latest
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+    - run: sudo apt-get install libjemalloc2 --yes
     - run: bundle install
     - run: bundle exec rake compile
     - run: bundle exec rake spec
+    - run: LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 bundle exec rake spec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,4 +14,5 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
     - run: bundle install
+    - run: bundle exec rake compile
     - run: bundle exec rake spec

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 certs/gem-private_key.pem
+lib/**/*.so

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,10 @@
 require 'bundler/gem_tasks'
 require 'yard'
 require 'rspec/core/rake_task'
+require "rake/extensiontask"
 
 unless ENV['RUBOCOP'] == 'false'
-  require 'rubocop/rake_task' 
+  require 'rubocop/rake_task'
 
   RuboCop::RakeTask.new(:rubocop) do |task|
     task.patterns = ['lib/**/*.rb', 'spec/**/*.rb']
@@ -23,6 +24,12 @@ end
 
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = %w(--color)
+end
+
+GEMSPEC = Gem::Specification.load("systemd-journal.gemspec")
+
+Rake::ExtensionTask.new("shim", GEMSPEC) do |ext|
+  ext.lib_dir = "lib/systemd/journal/"
 end
 
 task default: :spec

--- a/ext/shim/extconf.rb
+++ b/ext/shim/extconf.rb
@@ -7,4 +7,4 @@ require "mkmf"
 # selectively, or entirely remove this flag.
 append_cflags("-fvisibility=hidden")
 
-create_makefile("shim/shim")
+create_makefile("systemd/journal/shim")

--- a/ext/shim/extconf.rb
+++ b/ext/shim/extconf.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "mkmf"
+
+# Makes all symbols private by default to avoid unintended conflict
+# with other gems. To explicitly export symbols you can use RUBY_FUNC_EXPORTED
+# selectively, or entirely remove this flag.
+append_cflags("-fvisibility=hidden")
+
+create_makefile("shim/shim")

--- a/ext/shim/shim.c
+++ b/ext/shim/shim.c
@@ -1,0 +1,25 @@
+#include "shim.h"
+
+VALUE rb_mShim;
+
+VALUE shim_free(VALUE self, VALUE ptr);
+
+RUBY_FUNC_EXPORTED void
+Init_shim(void)
+{
+  VALUE mSystemd = rb_define_module("Systemd");
+  VALUE cJournal = rb_define_class_under(mSystemd, "Journal", rb_cObject);
+  rb_mShim = rb_define_module_under(cJournal, "Shim");
+
+  rb_define_module_function(rb_mShim, "free", shim_free, 1);
+}
+
+VALUE shim_free(VALUE self, VALUE ptr) {
+  VALUE rb_addr = rb_funcall(ptr, rb_intern("address"), 0);
+  void* addr = (void*)NUM2ULL(rb_addr);
+  if (addr) {
+    free(addr);
+  }
+
+  return Qnil;
+}

--- a/ext/shim/shim.h
+++ b/ext/shim/shim.h
@@ -1,0 +1,6 @@
+#ifndef SHIM_H
+#define SHIM_H 1
+
+#include "ruby.h"
+
+#endif /* SHIM_H */

--- a/lib/systemd/journal.rb
+++ b/lib/systemd/journal.rb
@@ -6,6 +6,7 @@ require 'systemd/journal/fields'
 require 'systemd/journal/navigable'
 require 'systemd/journal/filterable'
 require 'systemd/journal/waitable'
+require 'systemd/journal/shim'
 require 'systemd/journal_error'
 require 'systemd/journal_entry'
 require 'systemd/id128'
@@ -322,7 +323,7 @@ module Systemd
     # frees the char*, and returns the ruby string.
     def self.read_and_free_outstr(ptr)
       str = ptr.read_string
-      LibC.free(ptr)
+      Shim.free(ptr)
       str
     end
   end

--- a/lib/systemd/journal/native.rb
+++ b/lib/systemd/journal/native.rb
@@ -86,13 +86,4 @@ module Systemd
       attach_function :sd_journal_get_usage, [:pointer, :pointer], :int
     end
   end
-
-  # @private
-  module LibC
-    require 'ffi'
-    extend FFI::Library
-    ffi_lib FFI::Library::LIBC
-
-    attach_function :free, [:pointer], :void
-  end
 end

--- a/systemd-journal.gemspec
+++ b/systemd-journal.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
+  gem.extensions    = ["ext/shim/extconf.rb"]
 
   gem.required_ruby_version = '>= 1.9.3'
 
@@ -35,4 +36,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rubocop',   '~> 1.61' unless ENV['RUBOCOP'] == 'false'
   gem.add_development_dependency 'simplecov', '~> 0.22'
   gem.add_development_dependency 'yard',      '~> 0.9'
+  gem.add_development_dependency 'rake-compiler'
 end


### PR DESCRIPTION
Previously, we used LibC.free via ffi to release memory allocated by libsystemd (for example, via `sd_journal_get_catalog`).

However, if our process is running using a different allocator, for example jemalloc using `LD_PRELOAD`, attempting to use LibC to free a pointer allocated via jemalloc will cause a crash.

There's no good way via Ruby to determine which allocator is in use. Instead, we add this shim C code which invokes `free` -- it will pick up the same allocator (hopefully) as libsystemd used.

This can be tested by running specs under jemalloc; without this commit, the following will crash:

```bash
LD_PRELOAD=/usr/lib/libjemalloc.so rake spec
```