### PR TITLE
Reduce memory usage

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,5 +1,5 @@
 name: RSpec Matrix
-on: [push]
+on: [push, pull_request]
 jobs:
   test:
     strategy:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ j.current_entry # get the entry we're currently positioned at
 j.seek(Time.parse('2013-10-31T12:00:00+04:00:00'))
 ```
 
+Re-open the journal automatically to reduce memory usage with moving the journal:
+
+```ruby
+Journal.new(auto_reopen: false) # do not ever re-open the journal.
+                                # this should be the default for now
+
+Journal.new(auto_reopen: true)   # re-open the journal after the default ITERATIONS_TO_AUTO_REOPEN
+Journal.new(auto_reopen: 50_000) # re-open the journal after 50k iterations
+```
+
 Waiting for things to happen:
 
 ```ruby

--- a/lib/systemd/journal.rb
+++ b/lib/systemd/journal.rb
@@ -46,6 +46,7 @@ module Systemd
     #     path: '/var/log/journal/5f5777e46c5f4131bd9b71cbed6b9abf'
     #   )
     def initialize(opts = {})
+      @reopen_options = opts.dup # retain the options for auto reopen
       open_type, flags = validate_options!(opts)
       ptr = FFI::MemoryPointer.new(:pointer, 1)
 

--- a/lib/systemd/journal.rb
+++ b/lib/systemd/journal.rb
@@ -33,7 +33,7 @@ module Systemd
     # @param [Hash] opts optional initialization parameters.
     # @option opts [Integer] :flags a set of bitwise OR-ed
     #   {Systemd::Journal::Flags} which control what journal files are opened.
-    #   Defaults to `0`, meaning all journals avaiable to the current user.
+    #   Defaults to `0`, meaning all journals available to the current user.
     # @option opts [String] :path if provided, open the journal files living
     #   in the provided directory only.  Any provided flags will be ignored
     #   since sd_journal_open_directory does not currently accept any flags.

--- a/lib/systemd/journal.rb
+++ b/lib/systemd/journal.rb
@@ -26,6 +26,9 @@ module Systemd
     include Systemd::Journal::Filterable
     include Systemd::Journal::Waitable
 
+    # Returns the iterations to auto reopen
+    attr_reader :auto_reopen
+
     # Returns a new instance of a Journal, opened with the provided options.
     # @param [Hash] opts optional initialization parameters.
     # @option opts [Integer] :flags a set of bitwise OR-ed
@@ -50,6 +53,10 @@ module Systemd
       open_type, flags = validate_options!(opts)
       ptr = FFI::MemoryPointer.new(:pointer, 1)
 
+      @auto_reopen = (opts.key?(:auto_reopen) ? opts.delete(:auto_reopen) : false)
+      if @auto_reopen
+        @auto_reopen = @auto_reopen.is_a?(Integer) ? @auto_reopen : ITERATIONS_TO_AUTO_REOPEN
+      end
       @finalize = (opts.key?(:finalize) ? opts.delete(:finalize) : true)
       rc = open_journal(open_type, ptr, opts, flags)
       raise JournalError, rc if rc < 0

--- a/lib/systemd/journal/navigable.rb
+++ b/lib/systemd/journal/navigable.rb
@@ -1,6 +1,9 @@
 module Systemd
   class Journal
     module Navigable
+      LIMIT_TO_AUTO_REOPEN = 10_000
+      private_constant :LIMIT_TO_AUTO_REOPEN
+
       # returns a string representing the current read position.
       # This string can be passed to {#seek} or {#cursor?}.
       # @return [String] a cursor token.
@@ -40,9 +43,11 @@ module Systemd
       # @return [Boolean] False if unable to move to the next entry, indicating
       #   that the pointer has reached the end of the journal.
       def move_next
-        rc = Native.sd_journal_next(@ptr)
-        raise JournalError, rc if rc < 0
-        rc > 0
+        with_auto_reopen {
+          rc = Native.sd_journal_next(@ptr)
+          raise JournalError, rc if rc < 0
+          rc > 0
+        }
       end
 
       # Move the read pointer forward by `amount` entries.
@@ -50,9 +55,11 @@ module Systemd
       #   moved. If this number is less than the requested amount, the read
       #   pointer has reached the end of the journal.
       def move_next_skip(amount)
-        rc = Native.sd_journal_next_skip(@ptr, amount)
-        raise JournalError, rc if rc < 0
-        rc
+        with_auto_reopen {
+          rc = Native.sd_journal_next_skip(@ptr, amount)
+          raise JournalError, rc if rc < 0
+          rc
+        }
       end
 
       # Move the read pointer to the previous entry in the journal.
@@ -60,9 +67,11 @@ module Systemd
       # @return [Boolean] False if unable to move to the previous entry,
       #   indicating that the pointer has reached the beginning of the journal.
       def move_previous
-        rc = Native.sd_journal_previous(@ptr)
-        raise JournalError, rc if rc < 0
-        rc > 0
+        with_auto_reopen {
+          rc = Native.sd_journal_previous(@ptr)
+          raise JournalError, rc if rc < 0
+          rc > 0
+        }
       end
 
       # Move the read pointer backwards by `amount` entries.
@@ -70,9 +79,11 @@ module Systemd
       #   was moved.  If this number is less than the requested amount, the
       #   read pointer has reached the beginning of the journal.
       def move_previous_skip(amount)
-        rc = Native.sd_journal_previous_skip(@ptr, amount)
-        raise JournalError, rc if rc < 0
-        rc
+        with_auto_reopen {
+          rc = Native.sd_journal_previous_skip(@ptr, amount)
+          raise JournalError, rc if rc < 0
+          rc
+        }
       end
 
       # Seek to a position in the journal.
@@ -114,6 +125,33 @@ module Systemd
         raise JournalError, rc if rc < 0
 
         true
+      end
+
+      private
+
+      # reopen the journal automatically due to reduce memory usage
+      def with_auto_reopen
+        @sd_call_count ||= 0
+
+        ret = yield
+
+        @sd_call_count += 1
+        if @sd_call_count >= LIMIT_TO_AUTO_REOPEN
+          cursor = self.cursor
+
+          self.close
+          self.initialize(@reopen_options)
+
+          self.seek(cursor)
+          # To avoid 'Cannot assign requested address' error
+          # It invokes native API directly to avoid nest with_auto_reopen calls
+          rc = Native.sd_journal_next_skip(@ptr, 0)
+          raise JournalError, rc if rc < 0
+
+          @sd_call_count = 0
+        end
+
+        ret
       end
     end
   end

--- a/lib/systemd/journal/navigable.rb
+++ b/lib/systemd/journal/navigable.rb
@@ -101,7 +101,7 @@ module Systemd
       #   and seek to that entry.
       # @return [True]
       # @example Read last journal entry
-      #   j = Systemd::Joural.new
+      #   j = Systemd::Journal.new
       #   j.seek(:tail)
       #   j.move_previous
       #   puts j.current_entry

--- a/lib/systemd/journal_error.rb
+++ b/lib/systemd/journal_error.rb
@@ -1,7 +1,7 @@
 require 'ffi'
 
 module Systemd
-  # This execution is raised whenever a sd_journal_* call returns an error.
+  # This exception is raised whenever a sd_journal_* call returns an error.
   class JournalError < StandardError
     # Returns the (positive) error number.
     attr_reader :code

--- a/lib/systemd/journal_error.rb
+++ b/lib/systemd/journal_error.rb
@@ -1,7 +1,7 @@
 require 'ffi'
 
 module Systemd
-  # This execption is raised whenever a sd_journal_* call returns an error.
+  # This execution is raised whenever a sd_journal_* call returns an error.
   class JournalError < StandardError
     # Returns the (positive) error number.
     attr_reader :code

--- a/spec/systemd/journal_entry_spec.rb
+++ b/spec/systemd/journal_entry_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Systemd::JournalEntry do
           .to eq('Process 123 said test message')
       end
 
-      it 'skips field substition if requested' do
+      it 'skips field substitution if requested' do
         expect(entry.catalog(replace: false)).to eq(catalog)
       end
     end

--- a/spec/systemd/journal_spec.rb
+++ b/spec/systemd/journal_spec.rb
@@ -41,6 +41,39 @@ RSpec.describe Systemd::Journal do
 
       expect { j.new(container: 'test') }.to raise_error(ArgumentError)
     end
+
+    context 'auto_reopen' do
+      it 'returns nil as default behavior' do
+        journal = Systemd::Journal.new()
+        expect(journal.auto_reopen).to be_falsy
+      end
+
+      it 'returns default iterations with true' do
+        journal = Systemd::Journal.new(auto_reopen: true)
+        expect(journal.auto_reopen).to be_truthy
+      end
+
+      it 'returns nil with false' do
+        journal = Systemd::Journal.new(auto_reopen: false)
+        expect(journal.auto_reopen).to be_falsy
+      end
+
+      it 'returns iterations with custom value' do
+        journal = Systemd::Journal.new(auto_reopen: 12345)
+        expect(journal.auto_reopen).to be 12345
+      end
+
+      it 'should re-open internal journal pointer at specified iterations' do
+        journal = Systemd::Journal.new(auto_reopen: 2)
+        internal_journal = journal.instance_variable_get(:@ptr)
+
+        journal.move_next
+        expect(journal.instance_variable_get(:@ptr)).to be internal_journal
+
+        journal.move_next
+        expect(journal.instance_variable_get(:@ptr)).to_not be internal_journal
+      end
+    end
   end
 
   describe 'close' do


### PR DESCRIPTION
Fix https://github.com/ledbettj/systemd-journal/issues/102

When It move the cursor continuously, it increases memory usage in libsystemd internaly.
Unfortunatly, libsystemd does not provide the APIs to purge cache.

So, this patch will reopen the journal periodically to purge libsystemd's cache due to reduce memory usage.

## code
```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'systemd-journal'
end

journal = Systemd::Journal.new(path: '/var/log/journal')
journal.seek(:head)
count = 0

loop do
  journal.move_next
  count += 1

  if count % 100 == 0
    # print memory usage
    GC.start
    rss = `ps -o rss= -p #{Process.pid}`.to_f / 1024.0 # MB
    puts sprintf("%d,%.2f", count, rss)
  end
end
```

## result
![memory_uage](https://github.com/user-attachments/assets/d1fed0e3-862b-418e-b42c-0d27e490cf17)
