### PR TITLE
Fix filters deactivated after auto-reopen

### DIFF
--- a/lib/systemd/journal.rb
+++ b/lib/systemd/journal.rb
@@ -53,7 +53,7 @@ module Systemd
       open_type, flags = validate_options!(opts)
       ptr = FFI::MemoryPointer.new(:pointer, 1)
 
-      @reopen_filterable_matches = {} # retain the matches for auto reopen
+      @reopen_filter_conditions = [] # retain the conditions for auto reopen
       @auto_reopen = (opts.key?(:auto_reopen) ? opts.delete(:auto_reopen) : false)
       if @auto_reopen
         @auto_reopen = @auto_reopen.is_a?(Integer) ? @auto_reopen : ITERATIONS_TO_AUTO_REOPEN

--- a/lib/systemd/journal.rb
+++ b/lib/systemd/journal.rb
@@ -53,6 +53,7 @@ module Systemd
       open_type, flags = validate_options!(opts)
       ptr = FFI::MemoryPointer.new(:pointer, 1)
 
+      @reopen_filterable_matches = {} # retain the matches for auto reopen
       @auto_reopen = (opts.key?(:auto_reopen) ? opts.delete(:auto_reopen) : false)
       if @auto_reopen
         @auto_reopen = @auto_reopen.is_a?(Integer) ? @auto_reopen : ITERATIONS_TO_AUTO_REOPEN

--- a/lib/systemd/journal/filterable.rb
+++ b/lib/systemd/journal/filterable.rb
@@ -36,6 +36,8 @@ module Systemd
       # @param [String] value the match to search for, e.g. '/usr/bin/sshd'
       # @return [nil]
       def add_filter(field, value)
+        @reopen_filterable_matches[field] = value
+
         match = "#{field.to_s.upcase}=#{value}"
         rc = Native.sd_journal_add_match(@ptr, match, match.length)
         raise JournalError, rc if rc < 0

--- a/lib/systemd/journal/navigable.rb
+++ b/lib/systemd/journal/navigable.rb
@@ -145,12 +145,12 @@ module Systemd
               return
             end
 
-            matches = @reopen_filterable_matches.dup
+            filter_conditions = @reopen_filter_conditions.dup
 
             close
             initialize(@reopen_options)
 
-            filter(matches)
+            restore_filters(filter_conditions)
 
             seek(cursor)
             # To avoid 'Cannot assign requested address' error

--- a/lib/systemd/journal/navigable.rb
+++ b/lib/systemd/journal/navigable.rb
@@ -137,7 +137,14 @@ module Systemd
         if auto_reopen
           @sd_call_count += 1
           if @sd_call_count >= auto_reopen
-            cursor = self.cursor
+            begin
+              cursor = self.cursor
+            rescue
+              # Cancel the reopen process if cursor method causes 'Cannot assign requested address' error
+              @sd_call_count = 0
+              return
+            end
+
             matches = @reopen_filterable_matches.dup
 
             close

--- a/lib/systemd/journal/navigable.rb
+++ b/lib/systemd/journal/navigable.rb
@@ -138,9 +138,12 @@ module Systemd
           @sd_call_count += 1
           if @sd_call_count >= auto_reopen
             cursor = self.cursor
+            matches = @reopen_filterable_matches.dup
 
             close
             initialize(@reopen_options)
+
+            filter(matches)
 
             seek(cursor)
             # To avoid 'Cannot assign requested address' error

--- a/spec/systemd/journal_spec.rb
+++ b/spec/systemd/journal_spec.rb
@@ -65,6 +65,9 @@ RSpec.describe Systemd::Journal do
 
       it "should re-open internal journal pointer at specified iterations" do
         journal = Systemd::Journal.new(auto_reopen: 2)
+
+        condition = {_transport: "kernel"}
+        journal.filter(condition)
         internal_journal = journal.instance_variable_get(:@ptr)
 
         journal.move_next
@@ -72,6 +75,7 @@ RSpec.describe Systemd::Journal do
 
         journal.move_next
         expect(journal.instance_variable_get(:@ptr)).to_not be internal_journal
+        expect(journal.instance_variable_get(:@reopen_filterable_matches)).to eq condition
       end
     end
   end

--- a/spec/systemd/journal_spec.rb
+++ b/spec/systemd/journal_spec.rb
@@ -64,7 +64,9 @@ RSpec.describe Systemd::Journal do
       end
 
       it "should re-open internal journal pointer at specified iterations" do
-        journal = Systemd::Journal.new(auto_reopen: 2)
+        journal = Systemd::Journal.new(file: journal_file, auto_reopen: 3)
+        journal.seek(:head)
+        journal.move_next
 
         condition = {_transport: "kernel"}
         journal.filter(condition)

--- a/spec/systemd/journal_spec.rb
+++ b/spec/systemd/journal_spec.rb
@@ -64,12 +64,15 @@ RSpec.describe Systemd::Journal do
       end
 
       it "should re-open internal journal pointer at specified iterations" do
-        journal = Systemd::Journal.new(file: journal_file, auto_reopen: 3)
+        journal = Systemd::Journal.new(file: journal_file, auto_reopen: 2)
         journal.seek(:head)
-        journal.move_next
 
-        condition = {_transport: "kernel"}
-        journal.filter(condition)
+        journal.add_filters({syslog_identifier: "kernel"})
+        journal.add_conjunction
+        journal.add_filters({priority: "6"})
+        journal.add_disjunction
+        journal.add_filters({_transport: "kernel"})
+
         internal_journal = journal.instance_variable_get(:@ptr)
 
         journal.move_next
@@ -77,7 +80,13 @@ RSpec.describe Systemd::Journal do
 
         journal.move_next
         expect(journal.instance_variable_get(:@ptr)).to_not be internal_journal
-        expect(journal.instance_variable_get(:@reopen_filterable_matches)).to eq condition
+        expect(journal.instance_variable_get(:@reopen_filter_conditions)).to eq [
+          {syslog_identifier: "kernel"},
+          :conjunction,
+          {priority: "6"},
+          :disjunction,
+          {_transport: "kernel"}
+        ]
       end
     end
   end


### PR DESCRIPTION
Fix #108

I have improved memory usage at https://github.com/ledbettj/systemd-journal/pull/103
The filter conditions were not handled in auto-reopen operation, so they were cleared by initialization at
https://github.com/ledbettj/systemd-journal/blob/d154b198535b9d20e4b08397bb946e31e1c2be25/lib/systemd/journal/navigable.rb#L143

In this PR, it will restore the filter conditions after auto reopen journal.